### PR TITLE
PR fixes

### DIFF
--- a/src/Hazelcast.Net.Tests/CP/FencedLockTests.cs
+++ b/src/Hazelcast.Net.Tests/CP/FencedLockTests.cs
@@ -90,7 +90,7 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantLock()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
             await _lock.LockAsync();
@@ -102,13 +102,11 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantTryLock()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            bool locked = await _lock.TryLockAsync();
-            Assert.IsTrue(locked);
-            locked = await _lock.TryLockAsync();
-            Assert.IsTrue(locked);
+            Assert.IsTrue(await _lock.TryLockAsync());
+            Assert.IsTrue(await _lock.TryLockAsync());
             await _lock.UnlockAsync();
             await _lock.UnlockAsync();
         }
@@ -116,13 +114,11 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantTryLockTimeout()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            bool lock1 = await _lock.TryLockAsync(TimeSpan.FromSeconds(1));
-            bool lock2 = await _lock.TryLockAsync(TimeSpan.FromSeconds(1));
-            Assert.True(lock1);
-            Assert.True(lock2);
+            Assert.True(await _lock.TryLockAsync(TimeSpan.FromSeconds(1)));
+            Assert.True(await _lock.TryLockAsync(TimeSpan.FromSeconds(1)));
             await _lock.UnlockAsync();
             await _lock.UnlockAsync();
         }
@@ -130,7 +126,7 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantLockAndGetFence()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
             var fence1 = await _lock.LockAndGetFenceAsync();
             var fence2 = await _lock.LockAndGetFenceAsync();
@@ -138,10 +134,11 @@ namespace Hazelcast.Tests.CP
             Assert.AreNotEqual(FencedLock.InvalidFence, fence1);
             Assert.AreNotEqual(FencedLock.InvalidFence, fence2);
             Assert.AreEqual(fence1, fence2);
+
             var fence3 = await _lock.GetFenceAsync();
             Assert.AreEqual(fence1, fence3);
 
-            await AssertFencedLockValidAsync(_lock, 2, fence3);
+            await AssertIsLockedAsync(_lock, 2, fence3);
 
             await _lock.UnlockAsync();
             await _lock.UnlockAsync();
@@ -151,7 +148,7 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantTryLockAndGetFence()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
             var fence1 = await _lock.TryLockAndGetFenceAsync();
             var fence2 = await _lock.TryLockAndGetFenceAsync();
@@ -170,7 +167,7 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantTryLockAndGetFenceTimeout()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
             var fence1 = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
             var fence2 = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
@@ -187,264 +184,85 @@ namespace Hazelcast.Tests.CP
         }
 
         [Test]
-        public async Task TestTryLockWhileLockedByAnotherEndpoint()
+        public async Task TestTryLockWhileLockedByAnotherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
-
-            await DoLockOnAnotherContextAsync(lockName);
-
-            _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            bool locked = await _lock.TryLockAsync();//cannot take the lock
-            Assert.False(locked);
-        }
-
-
-        [Test]
-        [Timeout(5_000)]
-        public async Task TestTryLockConcurrentlyOnSameContext()
-        {
-            //We know that fenced lock chekcs the threadId to prevent race condition.
-            //It is done with threadId in Java by nature. OTOH, it's not the case in
-            //.net due to task based flow.So, whenever two flows from same context try
-            //to do operation on the lock, only one of them should be able to take the
-            //resource at the same time. Syncronization is done via SemaphoreSlim.
-            //Each context has own semaphore, and each flow holds the information
-            //whether got the semaphore or not(SemaphoreSlim doesn't know the its master).
-            //Hence, when a flow-master- takes the lock and so semaphore too, it holds
-            //that information in its local context too, so that it can release it later.
-
-            //The test tries to create a race condition to catch the exception. If Locker1
-            //is doing an operation, at the same time, Locker2 is trying to do similar,
-            //and one of them should get the exception. Unfourtunatly, we don't know which one
-            //will get the exception because we don't control the task scheduler.
-
-            var currentContext = AsyncContext.Current;
-            var _ = HConsoleForTest();
             var lockName = CreateUniqueName() + "@group1";
-
-            var tokenS = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-            var token = tokenS.Token;
-            var countOfAqusition1 = 0;
-            var countOfAqusition2 = 0;
-            var exceptionThrown = false;
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            async Task RunLocker1(CancellationToken token)
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            try
             {
-                try
-                {
-                    var myLock = await Client.CPSubsystem.GetLockAsync(lockName);
-
-                    while (await myLock.TryLockAsync() && !token.IsCancellationRequested)
-                    {
-                        HConsole.WriteLine(this, $"Locker 1 took the lock on Context:{currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                        countOfAqusition1++;
-                        await Task.Delay(7);//do some work
-                        await myLock.UnlockAsync();
-                        HConsole.WriteLine(this, $"Locker 1 released the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                    }
-                }
-                catch (LockOwnershipLostException ex)
-                {
-                    HConsole.WriteLine(this, $"Locker 1 Thread {Thread.CurrentThread.ManagedThreadId} :{ex.Message}");
-                    exceptionThrown = true;
-                }
+                Assert.False(await _lock.TryLockAsync()); // cannot take the lock
             }
-
-            async Task RunLocker2(CancellationToken token)
+            finally
             {
-                try
-                {
-                    var myLock = await Client.CPSubsystem.GetLockAsync(lockName);
-
-                    while (await myLock.TryLockAsync() && !token.IsCancellationRequested)
-                    {
-                        HConsole.WriteLine(this, $"Locker 2 took the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                        countOfAqusition2++;
-                        await Task.Delay(10);//do some work
-                        await myLock.UnlockAsync();
-                        HConsole.WriteLine(this, $"Locker 2 released the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                    }
-                }
-                catch (LockOwnershipLostException ex)
-                {
-                    HConsole.WriteLine(this, $"Locker 2 Thread {Thread.CurrentThread.ManagedThreadId} :{ex.Message}");
-                    exceptionThrown = true;
-                }
+                await otherContext.UnlockAsync();
             }
-
-            var lock1Task = RunLocker1(token);
-            var lock2Task = RunLocker2(token);
-            await Task.WhenAll(lock1Task, lock2Task);
-
-            if (countOfAqusition1 == 0 && countOfAqusition2 == 0)
-                Assert.Fail();//at least, one of them should got the lock
-
-            Assert.IsTrue(exceptionThrown, "Lockers owned the lock at the same time which shouldn't be occured.");
         }
 
         [Test]
-        public async Task TestTryLockParallelOnSameContext()
+        public async Task TestTryLockTimeoutWhileLockedByAnotherContext()
         {
-            //Visit TestTryLockConcurrentlyOnSameContext for explanation.
-
-            //Similar to test below but asigns task to thread pool.
-
-            AsyncContext.RequireNew();
-            var currentContext = AsyncContext.Current;
-            var _ = HConsoleForTest();
             var lockName = CreateUniqueName() + "@group1";
-            var tokenS = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-            var token = tokenS.Token;
-            var countOfAqusition1 = 0;
-            var countOfAqusition2 = 0;
-            var exceptionThrown = false;
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            var lock1Task = Task.Run(async () =>
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            try
             {
-                try
-                {
-                    var myLock = await Client.CPSubsystem.GetLockAsync(lockName);
-
-                    while (await myLock.TryLockAsync() && !token.IsCancellationRequested)
-                    {
-                        HConsole.WriteLine(this, $"Locker 2 took the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                        countOfAqusition2++;
-                        await Task.Delay(10);//do some work
-                        await myLock.UnlockAsync();
-                        HConsole.WriteLine(this, $"Locker 2 released the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                    }
-                }
-                catch (LockOwnershipLostException ex)
-                {
-                    HConsole.WriteLine(this, $"Context {AsyncContext.Current.Id}, Locker 1 Thread {Thread.CurrentThread.ManagedThreadId}  :{ex.Message}");
-                    exceptionThrown = true;
-                }
-            }, token);
-
-            var lock2Task = Task.Run(async () =>
+                Assert.False(await _lock.TryLockAsync(TimeSpan.FromSeconds(1))); // cannot take the lock
+            }
+            finally
             {
-                try
-                {
-                    var myLock = await Client.CPSubsystem.GetLockAsync(lockName);
-
-                    while (await myLock.TryLockAsync() && !token.IsCancellationRequested)
-                    {
-                        HConsole.WriteLine(this, $"Locker 2 took the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                        countOfAqusition2++;
-                        await Task.Delay(10);//do some work
-                        await myLock.UnlockAsync();
-                        HConsole.WriteLine(this, $"Locker 2 released the lock on Context: {currentContext.Id} Thread: {Thread.CurrentThread.ManagedThreadId}");
-                    }
-                }
-                catch (LockOwnershipLostException ex)
-                {
-                    HConsole.WriteLine(this, $"Context {AsyncContext.Current.Id}, Locker 2 Thread {Thread.CurrentThread.ManagedThreadId}  :{ex.Message}");
-                    exceptionThrown = true;
-                }
-            }, token);
-
-
-            await Task.WhenAll(lock1Task, lock2Task);
-
-            if (countOfAqusition1 == 0 && countOfAqusition2 == 0)
-                Assert.Fail();//at least, one of them should got the lock
-
-            Assert.IsTrue(exceptionThrown, "Lockers owned the lock at the same time which shouldn't be occured.");
+                await otherContext.UnlockAsync();
+            }
         }
-
-        [Test]
-        public async Task TestTryLockTimeoutWhileLockedByAnotherEndpoint()
-        {
-            string lockName = CreateUniqueName() + "@group1";
-
-            await DoLockOnAnotherContextAsync(lockName);
-
-            _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            bool locked = await _lock.TryLockAsync(TimeSpan.FromSeconds(1));//cannot take the lock
-            Assert.False(locked);
-        }
-
-        private async Task DoLockOnAnotherContextAsync(string lockName)
-        {
-            //lock by another context
-            await Task.Run(async () =>
-            {
-                try
-                {
-                    AsyncContext.RequireNew();
-                    var __lock = await Client.CPSubsystem.GetLockAsync(lockName);
-                    await __lock.LockAsync();
-                }
-                catch (Exception)
-                {
-                }
-
-            }).ConfigureAwait(false);
-        }
-
-        private async Task<long> DoTryLockAndGetFenceOnAnotherContextAsync(string lockName)
-        {
-            //lock by another context
-            return await Task.Run(async () =>
-            {
-                AsyncContext.RequireNew();
-                var __lock = await Client.CPSubsystem.GetLockAsync(lockName);
-                return await __lock.TryLockAndGetFenceAsync();
-
-            }).ConfigureAwait(false);
-        }
-
-        private async Task<long> DoLockOnAnotherContextAsync(string lockName, TimeSpan timeout)
-        {
-            //lock by another context
-            return await Task.Run(async () =>
-            {
-                AsyncContext.RequireNew();
-                var __lock = await Client.CPSubsystem.GetLockAsync(lockName);
-                return await __lock.TryLockAndGetFenceAsync(timeout);
-
-            }).ConfigureAwait(false);
-        }
-
 
         [Test]
         public async Task TestReentrantLockFails()
         {
-            string lockName = "non-reentrant-lock@group1";
+            const string lockName = "non-reentrant-lock@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+
             await _lock.LockAsync();
-            Assert.ThrowsAsync<LockAcquireLimitReachedException>(async () => await _lock.LockAsync());
+            await AssertEx.ThrowsAsync<LockAcquireLimitReachedException>(async () => await _lock.LockAsync());
+
             await _lock.UnlockAsync();
         }
 
         [Test]
         public async Task TestReentrantTryLockFails()
         {
-            string lockName = "non-reentrant-lock@group1";
+            const string lockName = "non-reentrant-lock@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+
             await _lock.LockAsync();
 
-            bool locked = await _lock.TryLockAsync();
-            Assert.False(locked);
-            Assert.True(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.TryLockAsync());
+            Assert.True(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
             Assert.AreNotEqual(FencedLock.InvalidFence, await _lock.GetFenceAsync());
+
             await _lock.UnlockAsync();
         }
 
         [Test]
         public async Task TestReentrantTryLockAndGetFenceFails()
         {
-            string lockName = "non-reentrant-lock@group1";
+            const string lockName = "non-reentrant-lock@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            await _lock.LockAsync();
-            long fence1 = await _lock.GetFenceAsync();
-            long fence2 = await _lock.TryLockAndGetFenceAsync();
 
+            await _lock.LockAsync();
+
+            var fence1 = await _lock.GetFenceAsync();
+            var fence2 = await _lock.TryLockAndGetFenceAsync();
+
+            Assert.AreNotEqual(FencedLock.InvalidFence, fence1);
             Assert.AreEqual(FencedLock.InvalidFence, fence2);
-            Assert.True(await _lock.IsLockedByCurrentContext());
+            Assert.True(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
             Assert.AreEqual(fence1, await _lock.GetFenceAsync());
 
@@ -454,15 +272,17 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantTryLockAndGetFenceTimeoutFails()
         {
-            string lockName = "non-reentrant-lock@group1";
+            const string lockName = "non-reentrant-lock@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+
             await _lock.LockAsync();
 
-            long fence1 = await _lock.GetFenceAsync();
+            var fence1 = await _lock.GetFenceAsync();
+            var fence2 = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
 
-            long fence2 = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
+            Assert.AreNotEqual(FencedLock.InvalidFence, fence1);
             Assert.AreEqual(FencedLock.InvalidFence, fence2);
-            Assert.True(await _lock.IsLockedByCurrentContext());
+            Assert.True(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
             Assert.AreEqual(fence1, await _lock.GetFenceAsync());
 
@@ -472,81 +292,77 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestReentrantLockAfterLockIsReleasedByAnotherEndpoint()
         {
-            string lockName = CreateUniqueName() + "@group1";
-            //lock by another context
-            await Task.Run(async () =>
-            {
-                AsyncContext.RequireNew();
-                var __lock = await Client.CPSubsystem.GetLockAsync(lockName);
-                await __lock.LockAsync();
-                await __lock.LockAsync();
-                await __lock.UnlockAsync();
-                await __lock.UnlockAsync();
-
-            }).ConfigureAwait(false);
-
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            await _lock.LockAsync();//cannot take the lock
-            long fence = await _lock.GetFenceAsync();
-            Assert.AreNotEqual(FencedLock.InvalidFence, fence);
-            Assert.True(await _lock.IsLockedByCurrentContext());
+
+            // same as Java test except that *other* locks and releases and *we*
+            // test the re-entrance whereas Java does it the other way round, but
+            // the result is the same - testing the very same thing
+
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            async Task Reenter()
+            {
+                await _lock.LockAsync();
+                await _lock.LockAsync();
+                await _lock.UnlockAsync();
+                await _lock.UnlockAsync();
+            }
+
+            var reentering = Reenter();
+            await otherContext.UnlockAsync();
+
+            var task = await Task.WhenAny(reentering, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.That(task, Is.EqualTo(reentering));
         }
 
-        //[Test]
+        [Test]
         public async Task TestAutoReleaseOnClientDispose()
         {
-            string lockName = CreateUniqueName() + "@group1";
-            _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+            var lockName = CreateUniqueName() + "@group1";
+            var client = await CreateAndStartClientAsync().CfAwait(); // use our own client since we are going to dispose it
+            _lock = await client.CPSubsystem.GetLockAsync(lockName);
 
             await _lock.LockAsync();
-            await Client.DisposeAsync();
+            await client.DisposeAsync();
 
-            string script = $"result = instance_0.getCPSubsystem().getLock(\"{lockName}\").isLocked() ? \"1\" : \"0\";";
+            var script = $"result = instance_0.getCPSubsystem().getLock(\"{lockName}\").isLocked() ? \"1\" : \"0\";";
 
-            var result = await RcClient.ExecuteOnControllerAsync(RcCluster.Id, script, Hazelcast.Testing.Remote.Lang.JAVASCRIPT);
-
-            Assert.That(int.Parse(Encoding.UTF8.GetString(result.Result)), Is.EqualTo(0));
+            await AssertEx.SucceedsEventually(async () =>
+            {
+                var result = await RcClient.ExecuteOnControllerAsync(RcCluster.Id, script, Hazelcast.Testing.Remote.Lang.JAVASCRIPT);
+                Assert.That(int.Parse(Encoding.UTF8.GetString(result.Result)), Is.EqualTo(0));
+            }, 10_000, 1000);
         }
 
         [Test]
         public async Task TestLock()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+
             await _lock.LockAsync();
-
-            await AssertFencedLockValidAsync(_lock);
-
+            await AssertIsLockedAsync(_lock);
             await _lock.UnlockAsync();
         }
 
-        private async Task AssertFencedLockValidAsync(IFencedLock _lock, int count = 1, long fence = -999)
+        private static async Task AssertIsLockedAsync(IFencedLock fencedLock, int count = 1, long? fence = default)
         {
-            if (fence != -999)
-                fence = await _lock.GetFenceAsync();
-
+            fence ??= await fencedLock.GetFenceAsync();
             Assert.AreNotEqual(FencedLock.InvalidFence, fence);
-            Assert.True(await _lock.IsLockedAsync());
-            Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(count));
-            Assert.True(await _lock.IsLockedByCurrentContext());
-        }
 
-        private async Task AssertFencedLockNotValidAsync(IFencedLock _lock, int count = 1, long fence = -999)
-        {
-            if (fence != -999)
-                fence = await _lock.GetFenceAsync();
-
-            Assert.AreNotEqual(FencedLock.InvalidFence, fence);
-            Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(count));
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.True(await fencedLock.IsLockedAsync());
+            Assert.That(await fencedLock.GetLockCountAsync(), Is.EqualTo(count));
+            Assert.True(await fencedLock.IsLockedByCurrentContextAsync());
         }
 
         [Test]
         public async Task TestLockAndGetFence()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            long fence = await _lock.LockAndGetFenceAsync();
+            var fence = await _lock.LockAndGetFenceAsync();
             Assert.AreNotEqual(FencedLock.InvalidFence, fence);
             await _lock.UnlockAsync();
         }
@@ -554,9 +370,9 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestTryLockAndGetFence()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            long fence = await _lock.TryLockAndGetFenceAsync();
+            var fence = await _lock.TryLockAndGetFenceAsync();
             Assert.AreNotEqual(FencedLock.InvalidFence, fence);
             await _lock.UnlockAsync();
         }
@@ -564,9 +380,9 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestTryLockAndGetFenceTimeout()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            long fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
+            var fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(1));
             Assert.AreNotEqual(FencedLock.InvalidFence, fence);
             await _lock.UnlockAsync();
         }
@@ -574,65 +390,67 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestTryLock()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            bool locked = await _lock.TryLockAsync();
+            var locked = await _lock.TryLockAsync();
             Assert.True(locked);
-            await AssertFencedLockValidAsync(_lock);
+            await AssertIsLockedAsync(_lock);
             await _lock.UnlockAsync();
         }
 
         [Test]
         public async Task TestTryLockTimeout()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-            bool locked = await _lock.TryLockAsync(TimeSpan.FromSeconds(1));
+            var locked = await _lock.TryLockAsync(TimeSpan.FromSeconds(1));
             Assert.True(locked);
-            await AssertFencedLockValidAsync(_lock);
+            await AssertIsLockedAsync(_lock);
             await _lock.UnlockAsync();
         }
 
         [Test]
-        public async Task TestLockWhenLockedByAnotherEndpoint()
+        public async Task TestLockWhenLockedByAnotherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
             await _lock.LockAsync();
 
-            var anotherLock = DoLockOnAnotherContextAsync(lockName);
+            var otherContext = new OtherContextLock(_lock);
+            var otherContextLocking = otherContext.LockAsync();
 
-            var completedFirst = await Task.WhenAny(anotherLock, Task.Delay(TimeSpan.FromSeconds(5)));
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            Assert.That(otherContextLocking.IsCompleted, Is.False);
+            await AssertIsLockedAsync(_lock);
 
-            if (completedFirst != anotherLock)
-                await AssertFencedLockValidAsync(_lock);
-            else
-                Assert.Fail("Other endpoint took the lock");
+            Assert.That(otherContextLocking.IsCompleted, Is.False);
+            await _lock.UnlockAsync();
+            await otherContextLocking;
         }
 
         [Test]
         public async Task TestUnlockWhenFree()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            Assert.ThrowsAsync<SynchronizationLockException>(async () => await _lock.UnlockAsync());
+            await AssertEx.ThrowsAsync<SynchronizationLockException>(async () => await _lock.UnlockAsync());
         }
 
         [Test]
         public async Task TestGetFenceWhenFree()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            Assert.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
+            await AssertEx.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
         }
 
         [Test]
         public async Task TestLockedFalseWhenFree()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
             Assert.False(await _lock.IsLockedAsync());
@@ -641,17 +459,16 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestIsLockedByCurrentThreadFalseWhenFree()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
         }
 
         [Test]
         public async Task TestLockCountZeroWhenFree()
         {
-            var _ = HConsoleForTest();
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
             await _lock.LockAsync();
@@ -660,257 +477,282 @@ namespace Hazelcast.Tests.CP
             Assert.False(await _lock.IsLockedAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(0));
 
-            Assert.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
+            await AssertEx.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
         }
 
         [Test]
-        public async Task TestLockUnlockThenLockOnOtherEndPoint()
+        public async Task TestLockUnlockThenLockOnOtherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-            await AssertFencedLockValidAsync(_lock, 1, fence);
-
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
             await _lock.UnlockAsync();
 
-            long newFence = await DoTryLockAndGetFenceOnAnotherContextAsync(lockName);
+            var otherContext = new OtherContextLock(_lock);
+            var otherFence = await otherContext.TryLockAndGetFenceAsync();
 
-            Assert.Greater(newFence, fence);
-
-            Assert.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
+            Assert.Greater(otherFence, fence);
+            await AssertEx.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
         }
 
         [Test]
-        public async Task TestUnlockWhenPendingLockOnOtherEndpoint()
+        public async Task TestUnlockWhenPendingLockOnOtherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
+            var fence = await _lock.LockAndGetFenceAsync();
 
-            var newFenceTask = DoLockOnAnotherContextAsync(lockName, TimeSpan.FromSeconds(60));
+            var otherContext = new OtherContextLock(_lock);
+            var otherFenceTask = otherContext.TryLockAndGetFenceAsync(TimeSpan.FromSeconds(60));
 
             await _lock.UnlockAsync();
 
-            long newFence = await newFenceTask;
+            var otherFence = await otherFenceTask;
 
-            Assert.Greater(newFence, fence);
+            Assert.Greater(otherFence, fence);
 
             Assert.True(await _lock.IsLockedAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
 
-            Assert.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
+            await AssertEx.ThrowsAsync<SynchronizationLockException>(async () => await _lock.GetFenceAsync());
+
+            await otherContext.UnlockAsync();
         }
 
         [Test]
-        public async Task TestUnlockWhenLockedOnOtherEndpoint()
+        public async Task TestUnlockWhenLockedOnOtherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            await DoLockOnAnotherContextAsync(lockName);
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
 
             Assert.ThrowsAsync<RemoteException>(async () => await _lock.UnlockAsync());
             Assert.True(await _lock.IsLockedAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
-            Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
-        }
-
-
-        [Test]
-        public async Task TestTryLockTimeoutWhenLockedOnOtherEndpoint()
-        {
-            string lockName = CreateUniqueName() + "@group1";
-            _lock = await Client.CPSubsystem.GetLockAsync(lockName);
-
-            await DoLockOnAnotherContextAsync(lockName);
-
-            long fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromMilliseconds(100));
-
-            Assert.AreEqual(FencedLock.InvalidFence, fence);
-            Assert.True(await _lock.IsLockedAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
         }
 
         [Test]
-        public async Task TestTryLockLongTimeoutWhenLockedOnOtherEndpoint()
+        public async Task TestTryLockTimeoutWhenLockedOnOtherContext()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            await DoLockOnAnotherContextAsync(lockName);
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
 
-            //1500 ms is upper bound of lock service
-            long fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromMilliseconds(1500 + 10));
+            var fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromMilliseconds(100));
 
             Assert.AreEqual(FencedLock.InvalidFence, fence);
             Assert.True(await _lock.IsLockedAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
+            Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestTryLockLongTimeoutWhenLockedOnOtherContext()
+        {
+            var lockName = CreateUniqueName() + "@group1";
+            _lock = await Client.CPSubsystem.GetLockAsync(lockName);
+
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            // "1500ms is upper bound of lock service"
+            // this is a direct copy of a Java test which comes without comments,
+            // and I have no idea what is the purpose of the test (note that 1500ms
+            // is not really a "max timeout" and a timeout of 20s is accepted as
+            // well...)
+            var fence = await _lock.TryLockAndGetFenceAsync(TimeSpan.FromMilliseconds(1500 + 1));
+
+            Assert.AreEqual(FencedLock.InvalidFence, fence);
+            Assert.True(await _lock.IsLockedAsync());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
             Assert.That(await _lock.GetLockCountAsync(), Is.EqualTo(1));
         }
 
         [Test]
         public async Task TestReentrantLockFailsWhenSessionClosed()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-            sessionService.InvalidateGroupSession(_lock.GroupId);
+            Assert.AreNotEqual(sessionId, CPSessionManager.NoSessionId);
 
-            await Task.Delay(6_000);
+            // here Java invokes closeSession which directly send a "close session" to the server
+            // but does NOT invalidate the session in the session service at all, so after a while
+            // the heartbeat thing will kick and invalidate the session and the session ID will
+            // change accordingly - we do the same
+            await sessionService.RequestCloseSessionAsync((CPGroupId) _lock.GroupId, sessionId);
 
-            var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+            // heartbeat delays is about 5s so give it plenty of time here
+            await AssertEx.SucceedsEventually(() =>
+            {
+                var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+                Assert.AreEqual(newSessionId, CPSessionManager.NoSessionId);
+            }, 20_000, 500);
 
-            Assert.AreNotEqual(newSessionId, sessionId);
-
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.LockAsync());
+            await AssertEx.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.LockAsync());
         }
 
         [Test]
         public async Task TestReentrantTryLockFailsWhenSessionClosed()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-
-            await AssertFencedLockValidAsync(_lock, 1, fence);
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-            sessionService.InvalidateGroupSession(_lock.GroupId);
+            Assert.AreNotEqual(sessionId, CPSessionManager.NoSessionId);
 
-            await Task.Delay(6_000);
+            // same as test above
+            await sessionService.RequestCloseSessionAsync((CPGroupId)_lock.GroupId, sessionId);
 
-            var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+            // heartbeat delays is about 5s so give it plenty of time here
+            await AssertEx.SucceedsEventually(() =>
+            {
+                var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+                Assert.AreEqual(newSessionId, CPSessionManager.NoSessionId);
+            }, 20_000, 500);
 
-            Assert.AreNotEqual(newSessionId, sessionId);
-
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.TryLockAsync());
+            await AssertEx.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.TryLockAsync());
         }
 
         [Test]
         public async Task TestReentrantTryLockTimeoutFailsWhenSessionClosed()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-
-            await AssertFencedLockValidAsync(_lock, 1, fence);
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-            await sessionService.CloseGroupSessionAsync(_lock.GroupId);
+            Assert.AreNotEqual(sessionId, CPSessionManager.NoSessionId);
 
-            var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+            // same as test above
+            await sessionService.RequestCloseSessionAsync((CPGroupId)_lock.GroupId, sessionId);
 
-            Assert.AreNotEqual(newSessionId, sessionId);
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.TryLockAsync(TimeSpan.FromSeconds(1)));
+            // heartbeat delays is about 5s so give it plenty of time here
+            await AssertEx.SucceedsEventually(() =>
+            {
+                var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+                Assert.AreEqual(newSessionId, CPSessionManager.NoSessionId);
+            }, 20_000, 500);
+
+            await AssertEx.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.TryLockAsync(TimeSpan.FromSeconds(1)));
             Assert.False(await _lock.IsLockedAsync());
         }
 
         [Test]
-        public async Task TestUnlocLockFailsWhenSessionClosed()
+        public async Task TestUnlockLockFailsWhenSessionClosed()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-
-            await AssertFencedLockValidAsync(_lock, 1, fence);
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-            await sessionService.CloseGroupSessionAsync(_lock.GroupId);
+            Assert.AreNotEqual(sessionId, CPSessionManager.NoSessionId);
 
-            var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+            // same as test above
+            await sessionService.RequestCloseSessionAsync((CPGroupId)_lock.GroupId, sessionId);
 
-            Assert.AreNotEqual(newSessionId, sessionId);
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.UnlockAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            // heartbeat delays is about 5s so give it plenty of time here
+            await AssertEx.SucceedsEventually(() =>
+            {
+                var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
+                Assert.AreEqual(newSessionId, CPSessionManager.NoSessionId);
+            }, 20_000, 500);
+
+            await AssertEx.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.UnlockAsync());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
             Assert.False(await _lock.IsLockedAsync());
         }
 
         [Test]
         public async Task TestUnlocLockFailsWhenSessionCreated()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-
-            await AssertFencedLockValidAsync(_lock, 1, fence);
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
             await sessionService.CloseGroupSessionAsync(_lock.GroupId);
 
             var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-
-            await DoLockOnAnotherContextAsync(lockName);
-
             Assert.AreNotEqual(newSessionId, sessionId);
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.UnlockAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
+
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            await AssertEx.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.UnlockAsync());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
 
         }
 
         [Test]
         public async Task TestGetFenceFailsWhenSessionCreated()
         {
-            var _ = HConsoleForTest();
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            long fence = await _lock.LockAndGetFenceAsync();
-
-            await AssertFencedLockValidAsync(_lock, 1, fence);
+            var fence = await _lock.LockAndGetFenceAsync();
+            await AssertIsLockedAsync(_lock, 1, fence);
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
             await sessionService.CloseGroupSessionAsync(_lock.GroupId);
 
             var newSessionId = sessionService.GetGroupSessionId(_lock.GroupId);
-
-            await DoLockOnAnotherContextAsync(lockName);
-
             Assert.AreNotEqual(newSessionId, sessionId);
-            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.GetFenceAsync());
-            Assert.False(await _lock.IsLockedByCurrentContext());
 
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
+
+            Assert.ThrowsAsync<LockOwnershipLostException>(async () => await _lock.GetFenceAsync());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
         }
 
         [Test]
         public async Task TestFailTryLockNotAcquireSession()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
 
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
-            await Task.Run(async () =>
-            {
-                AsyncContext.RequireNew();
-                await _lock.LockAsync();
-
-            }).ConfigureAwait(false);
+            var otherContext = new OtherContextLock(_lock);
+            await otherContext.LockAsync();
 
             var sessionService = Client.CPSubsystem.GetSessionManager();
             var sessionId = sessionService.GetGroupSessionId(_lock.GroupId);
 
             Assert.That(sessionService.GetAcquiredSessionCount((CPGroupId)_lock.GroupId, sessionId), Is.EqualTo(1));
 
-            long fence = await _lock.TryLockAndGetFenceAsync();
+            var fence = await _lock.TryLockAndGetFenceAsync();
 
             Assert.AreEqual(FencedLock.InvalidFence, fence);
-            Assert.False(await _lock.IsLockedByCurrentContext());
+            Assert.False(await _lock.IsLockedByCurrentContextAsync());
 
             Assert.That(sessionService.GetAcquiredSessionCount((CPGroupId)_lock.GroupId, sessionId), Is.EqualTo(1));
         }
@@ -918,14 +760,74 @@ namespace Hazelcast.Tests.CP
         [Test]
         public async Task TestDestroy()
         {
-            string lockName = CreateUniqueName() + "@group1";
+            var lockName = CreateUniqueName() + "@group1";
             _lock = await Client.CPSubsystem.GetLockAsync(lockName);
 
             await _lock.LockAsync();
-
             await _lock.DestroyAsync();
 
-            Assert.ThrowsAsync<RemoteException>(async () => await _lock.LockAsync());
+            await AssertEx.ThrowsAsync<RemoteException>(async () => await _lock.LockAsync());
+        }
+
+        private class OtherContextLock
+        {
+            private readonly IFencedLock _fencedLock;
+            private readonly TaskCompletionSource<long> _locked = new TaskCompletionSource<long>();
+            private readonly TaskCompletionSource<long> _unlock = new TaskCompletionSource<long>();
+            private Task _locking;
+
+            public OtherContextLock(IFencedLock fencedLock)
+            {
+                _fencedLock = fencedLock;
+            }
+
+            private async Task LockingAsync(int mode, TimeSpan timeout = default)
+            {
+                AsyncContext.RequireNew();
+                switch (mode)
+                {
+                    case 1:
+                        await _fencedLock.LockAsync().CfAwait();
+                        _locked.TrySetResult(-1);
+                        break;
+                    case 2:
+                        _locked.TrySetResult(await _fencedLock.TryLockAndGetFenceAsync().CfAwait());
+                        break;
+                    case 3:
+                        _locked.TrySetResult(await _fencedLock.TryLockAndGetFenceAsync(timeout).CfAwait());
+                        break;
+                }
+
+                await _unlock.Task.CfAwait();
+                await _fencedLock.UnlockAsync().CfAwait();
+            }
+
+            public Task LockAsync()
+            {
+                if (_locking != null) throw new InvalidOperationException();
+                _locking = LockingAsync(1);
+                return _locked.Task;
+            }
+
+            public Task<long> TryLockAndGetFenceAsync()
+            {
+                if (_locking != null) throw new InvalidOperationException();
+                _locking = LockingAsync(2);
+                return _locked.Task;
+            }
+
+            public Task<long> TryLockAndGetFenceAsync(TimeSpan timeout)
+            {
+                if (_locking != null) throw new InvalidOperationException();
+                _locking = LockingAsync(3, timeout);
+                return _locked.Task;
+            }
+
+            public Task UnlockAsync()
+            {
+                _unlock.TrySetResult(0);
+                return _locking;
+            }
         }
     }
 }

--- a/src/Hazelcast.Net/CP/CPDistributedObjectBase.cs
+++ b/src/Hazelcast.Net/CP/CPDistributedObjectBase.cs
@@ -14,8 +14,6 @@
 
 using System.Threading.Tasks;
 using Hazelcast.Clustering;
-using Hazelcast.Core;
-using Hazelcast.Protocol.Codecs;
 
 namespace Hazelcast.CP
 {
@@ -65,6 +63,6 @@ namespace Hazelcast.CP
         /// Doesn't do anything for now, but some cleanup may be implemented later. <para/>
         /// As such it is recommended to wrap object usage into <code>using</code> statement for better compatibility with future versions.
         /// </remarks>
-        public ValueTask DisposeAsync() => default;
+        public virtual ValueTask DisposeAsync() => default;
     }
 }

--- a/src/Hazelcast.Net/CP/CPSessionManager.Heartbeat.cs
+++ b/src/Hazelcast.Net/CP/CPSessionManager.Heartbeat.cs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Hazelcast.Core;

--- a/src/Hazelcast.Net/CP/CPSessionManager.Requests.cs
+++ b/src/Hazelcast.Net/CP/CPSessionManager.Requests.cs
@@ -31,7 +31,7 @@ namespace Hazelcast.CP
         /// </summary>
         /// <param name="groupId"></param>
         /// <returns></returns>
-        internal async Task<long> RequestGenerateThreadIdAsync(CPGroupId groupId)
+        private async Task<long> RequestGenerateThreadIdAsync(CPGroupId groupId)
         {
             var requestMessage = CPSessionGenerateThreadIdCodec.EncodeRequest(groupId);
             var responseMessage = await _cluster.Messaging.SendAsync(requestMessage).CfAwait();
@@ -44,7 +44,7 @@ namespace Hazelcast.CP
         /// </summary>
         /// <param name="groupId"></param>
         /// <returns>CPSession and heartbeat milliseconds</returns>
-        internal async Task<(CPSession, long)> RequestNewSessionAsync(CPGroupId groupId)
+        private async Task<(CPSession, long)> RequestNewSessionAsync(CPGroupId groupId)
         {
             var requestMessage = CPSessionCreateSessionCodec.EncodeRequest(groupId, _cluster.ClientId.ToString());
             var responseMessage = await _cluster.Messaging.SendAsync(requestMessage).CfAwait();
@@ -53,7 +53,7 @@ namespace Hazelcast.CP
         }
 
         /// <summary>
-        /// Closes the session on the server
+        /// (internal for tests) Closes the session on the server
         /// </summary>
         /// <param name="groupId"></param>
         /// <param name="sessionId"></param>
@@ -73,7 +73,7 @@ namespace Hazelcast.CP
         /// <param name="groupId"></param>
         /// <param name="sessionId"></param>
         /// <returns></returns>
-        internal async Task RequestSessionHeartbeat(CPGroupId groupId, long sessionId)
+        private async Task RequestSessionHeartbeat(CPGroupId groupId, long sessionId)
         {
             var requestMessage = CPSessionHeartbeatSessionCodec.EncodeRequest(groupId, sessionId);
             var responseMessage = await _cluster.Messaging.SendAsync(requestMessage).CfAwait();

--- a/src/Hazelcast.Net/CP/CPSubsystem.cs
+++ b/src/Hazelcast.Net/CP/CPSubsystem.cs
@@ -33,6 +33,7 @@ namespace Hazelcast.CP
         //internal for testing
         internal readonly CPSessionManager _cpSubsystemSession;
         private readonly ConcurrentDictionary<string, CPDistributedObjectBase> _cpObjectsByName = new ConcurrentDictionary<string, CPDistributedObjectBase>();
+        private readonly ConcurrentDictionary<string, IFencedLock> _fencedLocks = new ConcurrentDictionary<string, IFencedLock>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CPSubsystem"/> class.
@@ -67,7 +68,7 @@ namespace Hazelcast.CP
         /// <inheritdoc />
         public async Task<IAtomicLong> GetAtomicLongAsync(string name)
         {
-            var (groupName, objectName) = ParseName(name);
+            var (groupName, objectName, _) = ParseName(name);
             var groupId = await GetGroupIdAsync(groupName).CfAwait();
 
             return new AtomicLong(objectName, groupId, _cluster);
@@ -75,7 +76,7 @@ namespace Hazelcast.CP
 
         public async Task<IAtomicReference<T>> GetAtomicReferenceAsync<T>(string name)
         {
-            var (groupName, objectName) = ParseName(name);
+            var (groupName, objectName, _) = ParseName(name);
             var groupId = await GetGroupIdAsync(groupName).CfAwait();
 
             return new AtomicReference<T>(objectName, groupId, _cluster, _serializationService);
@@ -83,22 +84,46 @@ namespace Hazelcast.CP
 
         public async Task<IFencedLock> GetLockAsync(string name)
         {
-            var (groupName, objectName) = ParseName(name);
+            var (groupName, objectName, fullName) = ParseName(name);
             var groupId = await GetGroupIdAsync(groupName).CfAwait();
 
-            if (_cpObjectsByName.TryGetValue(objectName, out var cpObject) && cpObject is IFencedLock fencedLock)
+            // note: make sure to use the fully qualified fullName as a dictionary key
+
+            // the code we use is an exact match of the Java code
+            // TODO: think about simplifying with the commented code below
+            // TODO: make sure there is no race condition here
+            /*
+            while (true)
             {
-                if (cpObject.GroupId.Equals(groupId))
-                    return (IFencedLock)cpObject;
-                else
-                    _cpObjectsByName.TryRemove(objectName, out _);
+                var fencedLock = _fencedLocks.GetOrAdd(key, _ => new FencedLock(objectName, groupId, _cluster, _cpSubsystemSession));
+                if (fencedLock.GroupId.Equals(groupId))
+                    return fencedLock;
+
+                _fencedLocks.TryRemove(key, out _);
+                groupId = await GetGroupIdAsync(groupName).CfAwait();
             }
+            */
 
-            var newFencedLock = new FencedLock(objectName, groupId, _cluster, _cpSubsystemSession);
-            
-            var mostRecentLock = (FencedLock) _cpObjectsByName.GetOrAdd(objectName, newFencedLock);
+            while (true)
+            {
+                if (_fencedLocks.TryGetValue(fullName, out var fencedLock))
+                {
+                    // if the group ID matches, fine, else we are going to replace the lock
+                    if (fencedLock.GroupId.Equals(groupId))
+                        return fencedLock;
+                    _fencedLocks.TryRemove(fullName, out _);
+                }
 
-            return mostRecentLock;
+                // add a new fenced lock - there is a race condition, so another task may add one,
+                // and we need to verify that the group ID of the lock we get is correct (in case
+                // we don't add but just get the one that was added by the other task) - if it does
+                // not match then refresh the group ID and return - we want to be consistent
+                fencedLock = _fencedLocks.GetOrAdd(fullName, _ => new FencedLock(fullName, objectName, groupId, _cluster, _cpSubsystemSession));
+                if (fencedLock.GroupId.Equals(groupId))
+                    return fencedLock;
+
+                groupId = await GetGroupIdAsync(groupName).CfAwait();
+            }
         }
 
         // see: ClientRaftProxyFactory.java
@@ -116,7 +141,8 @@ namespace Hazelcast.CP
         internal const string DefaultGroupName = "default";
         internal const string MetaDataGroupName = "METADATA";
 
-        public static (string groupName, string objectName) ParseName(string name)
+        // name should be 'objectName' or 'objectName@groupName'
+        public static (string groupName, string objectName, string fullName) ParseName(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException(ExceptionMessages.NullOrEmpty);
 
@@ -149,7 +175,9 @@ namespace Hazelcast.CP
             if (objectName.Length == 0)
                 throw new ArgumentException("Object name cannot be empty string.", nameof(name));
 
-            return (groupName, objectName);
+            var fullName = objectName + '@' + groupName;
+
+            return (groupName, objectName, fullName);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Hazelcast.Net/CP/IFencedLock.cs
+++ b/src/Hazelcast.Net/CP/IFencedLock.cs
@@ -117,6 +117,6 @@ namespace Hazelcast.CP
         /// Gets whether the lock is held by the current <see cref="AsyncContext"/> or not.
         /// </summary>
         /// <returns<see cref="true"/> if the lock is held by the current <see cref="AsyncContext"/> otherwise <see cref = "false" /></returns>
-        Task<bool> IsLockedByCurrentContext();
+        Task<bool> IsLockedByCurrentContextAsync();
     }
 }

--- a/src/Hazelcast.Net/Core/AsyncContextLocker.cs
+++ b/src/Hazelcast.Net/Core/AsyncContextLocker.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hazelcast.Core
+{
+    internal class AsyncContextLocker : IDisposable
+    {
+        private readonly Dictionary<long, ContextLock> _contextLocks = new Dictionary<long, ContextLock>();
+        private int _disposed;
+
+        public async Task<IDisposable> LockAsync(long contextId)
+        {
+            ContextLock contextLock;
+
+            // there is one unique ContextLock instance (in _contextLocks) per contextId, and
+            // then each LockAsync caller gets one different instance of ContextLocked, and
+            // each one increments the reference count, and when each ContextLocked is disposed
+            // it releases the lock = next one can have it + decrements the reference count,
+            // and when the reference count is zero we know that there are no more tasks
+            // waiting and we remove the ContextLock. so it works like this:
+            // - first call creates a ContextLock (ref count == 1), locks, returns
+            // - second call gets the ContextLock (ref count == 2), waits for lock
+            // - first call completes = releases lock, releases ContextLock (ref count == 1),
+            //   keep ContextLock since ref count > 0 and it's referenced by second call
+            // - second call locks, returns
+            // - second call completes = releases lock, releases ContextLock (ref count == 0),
+            //   removes ContextLock since ref count == 0 and it's not referenced anymore
+
+            // atomically get from dictionary & increment the reference count
+            lock (_contextLocks)
+            {
+                if (!_contextLocks.TryGetValue(contextId, out contextLock))
+                    contextLock = _contextLocks[contextId] = new ContextLock(contextId);
+
+                contextLock.ReferenceCount++;
+            }
+
+            // may throw an ObjectDisposedException if the whole AsyncContextLocker is
+            // disposed while some tasks are still trying to obtain a lock, and that is
+            // normal behavior
+            await contextLock.WaitAsync().CfAwait();
+            return new ContextLocked(this, contextLock);
+        }
+
+        private void Release(ContextLock contextLock)
+        {
+            // release the lock
+            contextLock.Release();
+
+            // atomically decrement the reference count & remove from dictionary
+            lock (_contextLocks)
+            {
+                contextLock.ReferenceCount--;
+                if (contextLock.ReferenceCount == 0)
+                {
+                    _contextLocks.Remove(contextLock.ContextId);
+                    contextLock.Dispose(); // no references = no waiting tasks
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed.InterlockedZeroToOne()) return;
+            foreach (var contextLock in _contextLocks.Values)
+                contextLock.Dispose();
+            _contextLocks.Clear();
+        }
+
+        private class ContextLock : IDisposable
+        {
+            private readonly SemaphoreSlim _semaphore;
+
+            public ContextLock(long contextId)
+            {
+                _semaphore = new SemaphoreSlim(1, 1);
+                ContextId = contextId;
+            }
+
+            public long ContextId { get; }
+
+            public int ReferenceCount { get; set; }
+
+            public Task WaitAsync()
+            {
+                return _semaphore.WaitAsync();
+            }
+
+            public void Release()
+            {
+                _semaphore.Release();
+            }
+
+            public void Dispose()
+            {
+                _semaphore.Dispose();
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        private class ContextLocked : IDisposable
+        {
+            private readonly AsyncContextLocker _locker;
+            private readonly ContextLock _contextLock;
+
+            public ContextLocked(AsyncContextLocker locker, ContextLock contextLock)
+            {
+                _locker = locker;
+                _contextLock = contextLock;
+            }
+
+            public void Dispose()
+            {
+                _locker.Release(_contextLock);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/src/Hazelcast.Net/Core/Int32Extensions.cs
+++ b/src/Hazelcast.Net/Core/Int32Extensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Hazelcast.Core
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="int"/> value type.
+    /// </summary>
+    internal static class Int32Extensions
+    {
+        /// <summary>
+        /// Compares the value to zero and, if equal, replaces with one.
+        /// </summary>
+        /// <param name="value">The value to compare and replace.</param>
+        /// <returns><c>true</c> if the value was replaced; otherwise <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool InterlockedZeroToOne(this ref int value)
+        {
+            return Interlocked.CompareExchange(ref value, 1, 0) == 0;
+        }
+    }
+}


### PR DESCRIPTION
A different approach.

Race means that two tasks within the same context could enter any of the `FencedLock` method at the same time, which is not possible with Java. However it does not mean that we should prevent them from doing so, nor throw an exception in this case. Instead, we need to serialize these two tasks, ie make sure that one runs the method, and then the other one.

So I have refactored how we manage the lock and semaphore thing, with an external-to-fenced-lock mechanism to lock the async context. Each method locks the async context = no other task can enter at the same time, other tasks will have to wait. This way, we end up doing one thing at a time much like Java.

Have also fixed various things. Let's discuss.