### PR TITLE
PR fixes

### DIFF
--- a/src/Hazelcast.Net/CP/CPSubsystem.cs
+++ b/src/Hazelcast.Net/CP/CPSubsystem.cs
@@ -30,10 +30,10 @@ namespace Hazelcast.CP
     {
         private readonly Cluster _cluster;
         private readonly SerializationService _serializationService;
-        //internal for testing
-        internal readonly CPSessionManager _cpSubsystemSession;
-        private readonly ConcurrentDictionary<string, CPDistributedObjectBase> _cpObjectsByName = new ConcurrentDictionary<string, CPDistributedObjectBase>();
         private readonly ConcurrentDictionary<string, IFencedLock> _fencedLocks = new ConcurrentDictionary<string, IFencedLock>();
+
+        // ReSharper disable once InconsistentNaming - internal for tests
+        internal readonly CPSessionManager _cpSubsystemSession;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CPSubsystem"/> class.
@@ -182,9 +182,6 @@ namespace Hazelcast.CP
 
         public async ValueTask DisposeAsync()
         {
-            foreach (var item in _cpObjectsByName.Values)
-                await item.DestroyAsync().CfAwaitNoThrow();
-
             await _cpSubsystemSession.DisposeAsync().CfAwaitNoThrow();
         }
     }

--- a/src/Hazelcast.Net/CP/FencedLock.cs
+++ b/src/Hazelcast.Net/CP/FencedLock.cs
@@ -41,7 +41,7 @@ namespace Hazelcast.CP
         public FencedLock(string fullName, string objectName, CPGroupId groupId, Cluster cluster, CPSessionManager subsystemSession) 
             : base(ServiceNames.FencedLock, objectName, groupId, cluster)
         {
-            _fullName = fullName; // FIXME this should be a base class property
+            _fullName = fullName; // TODO: this should be a base class property
             _groupId = groupId;
             _cpSessionManager = subsystemSession;
         }
@@ -216,7 +216,7 @@ namespace Hazelcast.CP
                 catch (RemoteException e) when (e.Error == RemoteError.WaitKeyCancelledException)
                 {
                     _cpSessionManager.ReleaseSession(CPGroupId, sessionId);
-                    throw; // FIXME: Java throws new IllegalMonitorStateException
+                    throw; // note: Java throws new IllegalMonitorStateException
                 }
                 catch
                 {
@@ -316,7 +316,7 @@ namespace Hazelcast.CP
             if (sessionId == CPSessionManager.NoSessionId)
             {
                 _lockedSessionIds.TryRemove(contextId, out _);
-                throw new SynchronizationLockException(); // FIXME illegal monitor state?
+                throw new SynchronizationLockException(); // note: Java throws new IllegalMonitorStateException
             }
 
             try


### PR DESCRIPTION
More PR fixes: convert some `FIXME` comments to `TODO` as they are not critical, stop destroying locks when disposing the `CPSubsystem`.